### PR TITLE
Potential fix for code scanning alert no. 37: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/app/profile/profile.component.ts
+++ b/frontend/app/profile/profile.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -43,7 +44,8 @@ export class ProfileComponent {
         private router: Router,
         private ar: ActivatedRoute,
         private http: HttpClient,
-        private authService: AuthService
+        private authService: AuthService,
+        private sanitizer: DomSanitizer
     ) {
         this.storage = getStorage(this.authService.getApp());
         this.authService.onAuthStateChanged(
@@ -124,8 +126,8 @@ export class ProfileComponent {
                         oldDisplayName.toLowerCase() !=
                         this.userObj.displayName.toLowerCase()
                     ) {
-                        window.location.href =
-                            '/profile/' + this.tempUsername.toLowerCase();
+                        const sanitizedUrl = this.sanitizer.sanitize(4, '/profile/' + this.tempUsername.toLowerCase());
+                        window.location.href = sanitizedUrl;
                     } else if (oldDisplayName != this.userObj.displayName) {
                         window.location.reload();
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/Nathn/MasterQuizz/security/code-scanning/37](https://github.com/Nathn/MasterQuizz/security/code-scanning/37)

To fix the problem, we need to ensure that the `tempUsername` is properly sanitized before being used in constructing the URL. One effective way to do this is by using a library that provides functions for escaping or encoding user input to prevent XSS attacks. In this case, we can use Angular's built-in `DomSanitizer` service to sanitize the URL.

- Import the `DomSanitizer` service from `@angular/platform-browser`.
- Inject the `DomSanitizer` service into the constructor of the `ProfileComponent`.
- Use the `DomSanitizer` to sanitize the URL before assigning it to `window.location.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
